### PR TITLE
building 1.2.4 for defaults

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-aggregate_check: false
-upload_channels:
-  - services
-  - sfe1ed40
-channels:
-  - services
-  - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
     creates nested dictionaries from sent form/querystring data.
   license: MIT
   license_family: MIT
-  license_url: https://githuqb.com/bernii/querystring-parser/blob/master/LICENSE
+  license_url: https://github.com/bernii/querystring-parser/blob/master/LICENSE
   dev_url: https://github.com/bernii/querystring-parser
   doc_url: https://github.com/bernii/querystring-parser/blob/master/README.rst
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -41,11 +41,9 @@ about:
     creates nested dictionaries from sent form/querystring data.
   license: MIT
   license_family: MIT
-  license_file: LICENSE
-  license_url: https://github.com/bernii/querystring-parser/blob/master/LICENSE
+  license_url: https://githuqb.com/bernii/querystring-parser/blob/master/LICENSE
   dev_url: https://github.com/bernii/querystring-parser
   doc_url: https://github.com/bernii/querystring-parser/blob/master/README.rst
-  doc_source_url: https://github.com/bernii/querystring-parser/blob/master/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - wheel
   run:
     - python
-    - requests
     - six
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:


### PR DESCRIPTION
## Querystring_parser 1.2.4 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1794)
[Upstream](https://github.com/bernii/querystring-parser)
# Changes
- Updated version number and `sha256`
- Removed outdated dependencies 